### PR TITLE
Prefix attribute names to avoid "buttonSize" name conflict

### DIFF
--- a/spellcast/android-sender/res/layout/combat_fragment.xml
+++ b/spellcast/android-sender/res/layout/combat_fragment.xml
@@ -27,9 +27,9 @@ limitations under the License.
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@drawable/spell_rune_bg"
-        spellcast:buttonSize="@dimen/spellcast_spell_button_size"
+        spellcast:spellButtonSize="@dimen/spellcast_spell_button_size"
         android:layout_centerInParent="true"
-        spellcast:buttonPadding="0dp" />
+        spellcast:spellButtonPadding="0dp" />
 
     <ImageView
         android:id="@+id/success_fail_image"

--- a/spellcast/android-sender/res/values/attrs.xml
+++ b/spellcast/android-sender/res/values/attrs.xml
@@ -27,8 +27,8 @@ limitations under the License.
         <attr name="textSize" format="dimension"></attr>
     </declare-styleable>
     <declare-styleable name="SpellButtonCircle">
-        <attr name="buttonSize" format="dimension" />
-        <attr name="buttonPadding" format="dimension" />
+        <attr name="spellButtonSize" format="dimension" />
+        <attr name="spellButtonPadding" format="dimension" />
     </declare-styleable>
 
 </resources>


### PR DESCRIPTION
Updating to play-services-cast:8.4.0 or later causes build issues due to a name conflict with the custom attribute "buttonSize". This pull request prefixes the custom attributes to avoid the naming conflict.